### PR TITLE
Drop "between" examples from routemap syntax, at least for now.

### DIFF
--- a/route-matching-explainer.md
+++ b/route-matching-explainer.md
@@ -134,8 +134,7 @@ For example, a chat widget or members area might only appear in certain pages. A
      {"rules": [
         {"name": "home", "pattern": {"pathname": "/" } },
         {"name": "about", "pattern": {"pathname": "/about" } },
-        {"name": "article", "pattern": {"pathname": "/article/:article-id" } },
-        {"name": "between-articles", "between": ["article", "article"] }
+        {"name": "article", "pattern": {"pathname": "/article/:article-id" } }
      ]}
   </script>
 </head>
@@ -220,8 +219,7 @@ Together with the [patching](https://github.com/WICG/declarative-partial-updates
         {"pattern": {"pathname": "/*" }, "patchSource": "/content/patch", "mode": "same-document" },
         {"name": "home", "pattern": {"pathname": "/" } },
         {"name": "about", "pattern": {"pathname": "/about" } },
-        {"name": "article", "pattern": {"pathname": "/article/:article-id" } },
-        {"name": "between-articles", "between": ["article", "article"] }
+        {"name": "article", "pattern": {"pathname": "/article/:article-id" } }
      ]}
   </script>
 </head>


### PR DESCRIPTION
This drops the `between` examples from the routemap syntax since it seems unnecessary (for now, at least) and perhaps confusing to represent navigation between states at multiple layers (both in HTML and CSS).  (In particular, representing it at both layers leads to questions about what's supposed to happen when you use the "between" capabilities of both at the same time -- whether it's an error state, how that error is handled -- and that's both confusing and complex.)

I haven't added mention of this to the "Potential future enhancements" section yet -- it wasn't clear to me if it fit particularly well in one of the other sections (e..g, because that section would motivate reintroducing it), whether it should have its own section (though it's pretty small), or whether we should just let it drop from the explainer for now.  (I'm happy to revise this PR to reflect opinions/discussion on this question.)