### PR TITLE
Add workflow to auto-publish css-route-matching to gh-pages.

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,21 @@
+name: Automatic Publication
+
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+
+jobs:
+  validate-and-publish:
+    name: Build, Validate, and Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: bikeshed
+          GH_PAGES_BRANCH: gh-pages
+          SOURCE: css-route-matching/index.bs
+

--- a/css-route-matching/index.bs
+++ b/css-route-matching/index.bs
@@ -7,7 +7,7 @@ Org: w3c
 Level: 1
 Repository: WICG/declarative-route-matching
 !Issue Tracking: <a href="https://github.com/w3c/csswg-drafts/issues/12594">w3c/csswg-drafts#12594</a>
-ED: https://wicg.github.io/declarative-partial-updates/css-route-matching.html
+ED: https://wicg.github.io/declarative-partial-updates/css-route-matching/
 Editor: L. David Baron, Google https://www.google.com/, https://dbaron.org/, w3cid 15393
 Editor: Noam Rosenthal, Google https://www.google.com/, w3cid 121539
 Abstract: This module contains conditional CSS rules for styling based on routes


### PR DESCRIPTION
This adds a workflow to auto-publish the css-route-matching draft to gh-pages.  It moves it into a subdirectory so that only the spec and not all the other files get put on the gh-pages branch.