### PR TITLE
Fill in definitions of from and to.

### DIFF
--- a/css-route-matching/index.bs
+++ b/css-route-matching/index.bs
@@ -16,6 +16,18 @@ Abstract: This module contains conditional CSS rules for styling based on routes
 </pre>
 <!-- for now using Org: w3c rather than Group: csswg because the latter forces an incorrect issue tracking link, overriding Repository -->
 
+<!-- FIXME: TEMPORARILY override non-exported definition -->
+<pre class=anchors>
+url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-navigationtransition-from
+	type: dfn; spec: html; text: from entry;
+url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-navigation-api
+	type: dfn; spec: html; text: navigation API;
+url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#ongoing-navigate-event
+	type: dfn; spec: html; text: ongoing navigate event;
+url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-navigation-transition
+	type: dfn; spec: html; text: transition;
+</pre>
+
 <h2 id="at-route">Route queries: the ''@route'' rule</h2>
 
 The <dfn at-rule id="at-ruledef-route">@route</dfn> rule
@@ -59,7 +71,7 @@ with <<route-condition>> defined as:
 	                     | <<route-in-parens>> [ or <<route-in-parens>> ]*
 	<dfn><<route-in-parens>></dfn> = ( <<route-condition>> ) | ( <<route-test>> ) | <<general-enclosed>>
 	<dfn><<route-test>></dfn> = <<route-name>> | <<route-keyword>> : <<route-name>>
-	<dfn><<route-keyword>></dfn> = at | to | from
+	<dfn><<route-keyword>></dfn> = at | from | to
 	<!-- TODO(dbaron): Should this be <<ident>> or <<custom-ident>> ? -->
 	<dfn><<route-name>></dfn> = <<custom-ident>>
 </pre>
@@ -107,21 +119,42 @@ as follows:
 		the URL pattern of a route named <<route-name>>
 		declared in a <code highlight=html>&lt;script type=routemap></code>.
 
-	: to: <<route-name>>
+	: from: <<route-name>>
 	:: The result is true if
-		the document's [=node navigable=]'s
-		@@@ @@@ <span class="issue">define this properly</span>
+		the [=document's navigation API=] of the document
+		is non-null,
+		its [=transition=] is non-null,
+		its [=from entry=]'s {{NavigationHistoryEntry/url}}
+		is non-null and
 		[=URL pattern/match|matches=]
 		the URL pattern of a route named <<route-name>>
 		declared in a <code highlight=html>&lt;script type=routemap></code>.
 
-	: from: <<route-name>>
+	: to: <<route-name>>
 	:: The result is true if
-		the document's [=node navigable=]'s
-		@@@ @@@ <span class="issue">define this properly</span>
+		the [=document's navigation API=] of the document
+		is non-null,
+		its [=ongoing navigate event=] is non-null,
+		and its {{NavigateEvent/destination}}'s
+		{{NavigationDestination/url}}
 		[=URL pattern/match|matches=]
 		the URL pattern of a route named <<route-name>>
 		declared in a <code highlight=html>&lt;script type=routemap></code>.
+
+		<!--
+
+		After
+		<a href="https://github.com/whatwg/html/issues/11690">whatwg/html#11690</a> /
+		<a href="https://github.com/whatwg/html/pull/11692">whatwg/html#11692</a>.
+		we could probably define this more like "from" above.  But it's probably
+		also OK as is since the transition and the ongoing navigate event basically have
+		the same lifetime.
+
+		-->
+
+	ISSUE: The above definitions of from and to probably don't do the right thing
+	during the loading of the new document in a cross-document navigation,
+	since I think they reference concepts that are only present on the old document.
 
 	ISSUE: Once routemaps are defined more formally,
 	this should be defined in terms of the routemap definition
@@ -134,6 +167,14 @@ as follows:
 	Authors must not use <<general-enclosed>> in their stylesheets.
 	<span class='note'>It exists only for future-compatibility,
 	so that new syntax additions do not invalidate too much of a <<route-condition>> in older user agents.</span>
+
+Define a <dfn>document's navigation API</dfn> as the result of the following steps on <var>document</var>:
+
+1. Let <var>window</var> be the {{Window}} whose [=associated Document=] is <var>document</var>, or null if there is no such {{Window}}.
+
+1. If <var>window</var> is null, return null.
+
+1. Return <var>window</var>'s [=navigation API=].
 
 The condition of the ''@route'' rule
 is the result of the <<route-condition>> in its prelude.

--- a/css-route-matching/index.bs
+++ b/css-route-matching/index.bs
@@ -156,6 +156,10 @@ as follows:
 	during the loading of the new document in a cross-document navigation,
 	since I think they reference concepts that are only present on the old document.
 
+	ISSUE: The above definitions of from and to apparently don't work right
+	if you start a same-document navigation (e.g., with {{History/pushState}})
+	in the middle of a cross-document navigation.
+
 	ISSUE: Once routemaps are defined more formally,
 	this should be defined in terms of the routemap definition
 	instead of referring directly to URLPattern.


### PR DESCRIPTION
This sort of fills in (modulo some issues noted in the text) the placeholders that I left in the definitions of "from" and "to".

(I'm curious if @noamr agrees with my description of the issue.)