### PR TITLE
Also match from/to based on navigation.activation information.

### DIFF
--- a/css-route-matching/index.bs
+++ b/css-route-matching/index.bs
@@ -26,6 +26,12 @@ url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#ongoing-naviga
 	type: dfn; spec: html; text: ongoing navigate event;
 url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-navigation-transition
 	type: dfn; spec: html; text: transition;
+url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-activation
+	type: dfn; spec: html; text: activation;
+url: https://html.spec.whatwg.org/multipage/browsing-the-web.html#reveal
+	type: dfn; spec: html; text: reveal a document;
+url: https://html.spec.whatwg.org/multipage/browsing-the-web.html#has-been-revealed
+	type: dfn; spec: html; text: has been revealed;
 </pre>
 
 <h2 id="at-route">Route queries: the ''@route'' rule</h2>
@@ -122,41 +128,60 @@ as follows:
 	: from: <<route-location>>
 	:: The result is true if
 		the [=document's navigation API=] of the document
-		is non-null,
-		its [=transition=] is non-null,
-		its [=from entry=]'s {{NavigationHistoryEntry/url}}
-		is non-null and
-		[=URL pattern/match|matches=]
-		the [=route location URL pattern=] of <<route-location>>.
+		is non-null, and either:
+
+		* its [=transition=] is non-null,
+			its [=from entry=]'s {{NavigationHistoryEntry/url}}
+			is non-null and
+			[=URL pattern/match|matches=]
+			the [=route location URL pattern=] of <<route-location>>.
+
+		* its [=activation=] is non-null,
+			the document's [=has been revealed=] is false or
+			the [=reveal a document=] steps that began when
+			[=has been revealed=] was false are still running,
+			and the activation's {{NavigationActivation/from}}'s
+			{{NavigationHistoryEntry/url}}'s
+			is non-null and
+			[=URL pattern/match|matches=]
+			the [=route location URL pattern=] of <<route-location>>.
 
 	: to: <<route-location>>
 	:: The result is true if
 		the [=document's navigation API=] of the document
-		is non-null,
-		its [=ongoing navigate event=] is non-null,
-		and its {{NavigateEvent/destination}}'s
-		{{NavigationDestination/url}}
-		[=URL pattern/match|matches=]
-		the [=route location URL pattern=] of <<route-location>>.
+		is non-null, and either:
 
-		<!--
+		* its [=ongoing navigate event=] is non-null,
+			and its {{NavigateEvent/destination}}'s
+			{{NavigationDestination/url}}
+			[=URL pattern/match|matches=]
+			the [=route location URL pattern=] of <<route-location>>.
 
-		After
-		<a href="https://github.com/whatwg/html/issues/11690">whatwg/html#11690</a> /
-		<a href="https://github.com/whatwg/html/pull/11692">whatwg/html#11692</a>.
-		we could probably define this more like "from" above.  But it's probably
-		also OK as is since the transition and the ongoing navigate event basically have
-		the same lifetime.
+			ISSUE: This assumes that the [=ongoing navigate event=]
+			and the [=transition=] have the same lifetime,
+			but this isn't really
+			true if the event is intercepted.
+			After
+			<a href="https://github.com/whatwg/html/issues/11690">whatwg/html#11690</a> /
+			<a href="https://github.com/whatwg/html/pull/11692">whatwg/html#11692</a>.
+			we could probably define this more like "from" above.
+			But which lifetime is the one we want?
 
-		-->
-
-	ISSUE: The above definitions of from and to probably don't do the right thing
-	during the loading of the new document in a cross-document navigation,
-	since I think they reference concepts that are only present on the old document.
+		* its [=activation=] is non-null,
+			the document's [=has been revealed=] is false or
+			the [=reveal a document=] steps that began when
+			[=has been revealed=] was false are still running,
+			and the activation's {{NavigationActivation/entry}}'s
+			{{NavigationHistoryEntry/url}}'s
+			is non-null and
+			[=URL pattern/match|matches=]
+			the [=route location URL pattern=] of <<route-location>>.
 
 	ISSUE: The above definitions of from and to apparently don't work right
 	if you start a same-document navigation (e.g., with {{History/pushState}})
 	in the middle of a cross-document navigation.
+
+	ISSUE: Improve integration with [=reveal a document=] rather than monkeypatching it.
 
 : <<general-enclosed>>
 ::


### PR DESCRIPTION
This adds some wording to also consider `navigation.activation` based on a suggestion from @noamr.  I suspect this fully resolves the issue that I deleted in this PR ([visible in current spec](https://wicg.github.io/declarative-partial-updates/css-route-matching/#issue-23009793) for now), but I'd definitely like @noamr to check that he agrees.

The way this integrates with "reveal a document" is pretty monkeypatch-ey, but I think it's fine for now and we should fix it later as this stabilizes.

Also curious if @noamr has an opinion on whether the "transition" lifetime or the "ongoing navigate event" lifetime is correct -- I think they differ when the navigate event is intercepted.  (I turned that from a code comment into an actual `ISSUE` in this PR.)