### PR TITLE
Rename `:nav-source` to `:navigation-source`

### DIFF
--- a/route-matching-explainer.md
+++ b/route-matching-explainer.md
@@ -311,10 +311,10 @@ a:link-to(url("/exact?a=1")) { ... }
 
 The navigation's [source element](https://html.spec.whatwg.org/multipage/#navigation-source-element) is a link, form, or submit button.
 
-The `:nav-source` pseudo class allows styling that particular link, for the course of the navigation:
+The `:navigation-source` pseudo class allows styling that particular link, for the course of the navigation:
 
 ```css
-:nav-source { animation-name: blink; } 
+:navigation-source { animation-name: blink; } 
 ```
 
 ## Potential future enhancements


### PR DESCRIPTION
As per CSSWG resolution in https://github.com/w3c/csswg-drafts/issues/14303#issuecomment-5400230306

_(I noticed just now that the commit message has a spelling error, but a squash merge can fix this)_